### PR TITLE
change colors from rgb > floating-point for love 11.x support

### DIFF
--- a/Camera.lua
+++ b/Camera.lua
@@ -91,7 +91,7 @@ local function new(x, y, w, h, scale, rotation)
         follow_lead_x = 0, follow_lead_y = 0,
         deadzone = nil, bound = nil,
         draw_deadzone = false,
-        flash_duration = 1, flash_timer = 0, flash_color = {0, 0, 0, 255},
+        flash_duration = 1, flash_timer = 0, flash_color = {0, 0, 0, 1},
         fade_duration = 1, fade_timer = 0, fade_color = {0, 0, 0, 0},
     }, Camera)
 end

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ end
 
 function love.keypressed(key)
     if key == 'f' then
-        camera:flash(0.05, {0, 0, 0, 255})
+        camera:flash(0.05, {0, 0, 0, 1})
     end
 end
 ```
@@ -320,7 +320,7 @@ end
 
 function love.keypressed(key)
     if key == 'f' then
-        camera:fade(1, {0, 0, 0, 255})
+        camera:fade(1, {0, 0, 0, 1})
     end
     
     if key == 'g' then
@@ -361,7 +361,7 @@ function love.draw()
     love.graphics.setCanvas()
     
     -- Draw the 400x300 canvas scaled by 2 to a 800x600 screen
-    love.graphics.setColor(255, 255, 255, 255)
+    love.graphics.setColor(1, 1, 1, 1)
     love.graphics.setBlendMode('alpha', 'premultiplied')
     love.graphics.draw(canvas, 0, 0, 0, 2, 2)
     love.graphics.setBlendMode('alpha')
@@ -667,13 +667,13 @@ Arguments:
 Fills the screen up with a color for a certain duration.
 
 ```lua
-camera:flash(0.05, {0, 0, 0, 255})
+camera:flash(0.05, {0, 0, 0, 1})
 ```
 
 Arguments:
 
 * `duration` `(number)` - The duration of the flash in seconds
-* `color={0, 0, 0, 255}` `(table[number])` - The color of the flash. Defaults to `{0, 0, 0, 255}`
+* `color={0, 0, 0, 1}` `(table[number])` - The color of the flash. Defaults to `{0, 0, 0, 1}`
 
 ---
 
@@ -682,7 +682,7 @@ Arguments:
 Slowly fills up the screen with a color along the duration.
 
 ```lua
-camera:fade(1, {0, 0, 0, 255}, function() print(1) end)
+camera:fade(1, {0, 0, 0, 1}, function() print(1) end)
 ```
 
 Arguments: 


### PR DESCRIPTION
Changed color values to support love2d 11.x.
Color values are now assigned with 0-1 instead of 0-255

See Changelog: https://love2d.org/wiki/11.0

>...
    Changed all color values to be in the range 0-1, rather than 0-255. This affects the following functions:
        love.graphics.setColor, love.graphics.getColor, love.graphics.setBackgroundColor, and love.graphics.getBackgroundColor.
...